### PR TITLE
new param, static-custom, advice

### DIFF
--- a/dhcp-dns
+++ b/dhcp-dns
@@ -7,9 +7,10 @@
 :local dhcpip
 :local dnsnode
 :local dhcpnode
+:local dhcpserver
 
 /ip dns static;
-:foreach i in=[find where name ~ (".*\\.".$zone) ] do={
+:foreach i in=[find where name ~ (".*\\.".$zone) && comment=""] do={
   :set hostname [ get $i name ];
   :set comment [get $i comment ];
   :set hostname [ :pick $hostname 0 ( [ :len $hostname ] - ( [ :len $zone ] + 1 ) ) ];
@@ -41,7 +42,7 @@
 }
 
 /ip dhcp-server lease;
-:foreach i in=[find] do={
+:foreach i in=[find where server=$dhcpserver] do={
   :set hostname ""
   :local mac
   :set dhcpip [ get $i address ];


### PR DESCRIPTION
add new var - dhcpserver
it mean, what is chain dns-zone and dhcp-server will be used
and filter function find in dhcp-lease work only with certain dhcp-server name

static-custom
now script work (add and remove) with only empty-comments dns-dhcp-records because user can add static dns record for custom
but he must set comment of course.

and good advice. script can be run in lease-script (only if new records aviable). no necessary run it in schedule.
for example:
/ip dhcp-server
add address-pool=dhcp-home authoritative=after-2sec-delay disabled=no interface=bridge-local lease-script="system script run dhcpset" lease-time=52w1d name=dhcp-server-home